### PR TITLE
Improve README with SLAM overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,53 @@
-# Computer Vision Offline Demos
+# Visual SLAM Pipeline
 
-Collection of small yet self‑contained algorithms for demonstrating offline
-computer vision pipelines:
+This repository implements a Python based **visual SLAM** pipeline capable of
+estimating camera trajectories from a video sequence. The implementation is
+compact yet complete and features:
 
-* **Visual SLAM prototype** (see `visual_slam_offline_entry_point.py`) using
-  ORB features and a RANSAC‑robust homography. Results are visualised with
-  `VehiclePathLiveAnimator`.
-* **Pose‑graph optimiser and loop‑closure utilities** used by the SLAM demo
-  (`pose_graph.py`, `loop_closure.py`).
+* **Main entry point** – `visual_slam_offline_entry_point.py` extracts ORB
+  features, estimates motion using a RANSAC‑robust homography and visualises
+  the trajectory with `VehiclePathLiveAnimator`.
+* **Pose‑graph optimisation** – the `pose_graph.py` module maintains a graph of
+  camera poses and refines it when loops are detected.
+* **Loop closure detection** – `loop_closure.py` implements a simple BoW
+  database for recognising previously seen locations.
+* Additional helpers for homography estimation and camera intrinsics.
 
-### Development
+## Repository structure
+
+The most relevant modules are:
+
+* `visual_slam_offline_entry_point.py` – main entry point running the pipeline
+* `pose_graph.py` – pose graph data structure and optimisation logic
+* `loop_closure.py` – simple BoW database for detecting revisited places
+* `homography.py` – feature-based homography estimation utilities
+* `cam_intrinsics_estimation.py` – optional camera calibration helpers
+
+## Running the pipeline
+
+The repository ships with a short example clip `sharp_curve.mp4`.  Use the
+entry‑point script to process the video and display the recovered trajectory:
+
+```bash
+python visual_slam_offline_entry_point.py --video sharp_curve.mp4
+```
+
+The script loads frames from the given video, detects ORB keypoints and
+estimates planar motion between successive images.  Each transform is appended
+to a pose graph and the current vehicle path is shown in a Matplotlib window.
+When the BoW database identifies a loop, the graph is optimised and the plot is
+updated with the refined trajectory.
+
+Useful flags:
+
+* `--max_frames N` – limit the number of processed frames.
+* `--semantic_masking` – mask dynamic regions before feature detection using a
+  simple frame‑difference algorithm.
+
+## Development
 
 Tests require Python 3.11+ with `numpy`, `opencv‑python‑headless`,
-`matplotlib` and `pytest` installed.  Run them with:
+`matplotlib`, `scikit‑learn` and `pytest` installed.  Run them with:
 
 ```bash
 pytest -q


### PR DESCRIPTION
## Summary
- rewrite README introduction to highlight capabilities
- rename running section to "Running the pipeline"
- keep instructions on executing `visual_slam_offline_entry_point.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854032c6fe08322b3032ec65f6f5d35