### PR TITLE
Enhance path visualization

### DIFF
--- a/slam_path_estimator.py
+++ b/slam_path_estimator.py
@@ -7,6 +7,7 @@ import threading
 import time
 
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
 import numpy as np
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,8 @@ class VehiclePathLiveAnimator:
         self.optimized_poses: list[np.ndarray] | None = None
         self.positions: list[np.ndarray] = [np.array([0.0, 0.0])]
         self.optimized_positions: list[np.ndarray] | None = None
+        self.loop_edges: list[tuple[int, int]] = []
+        self.loop_lines: list[Line2D] = []
         self.new_data_available = False
         self.running = True
         self.lock = threading.Lock()
@@ -26,13 +29,14 @@ class VehiclePathLiveAnimator:
         # Setup plot
         plt.ion()
         self.fig, self.ax = plt.subplots(figsize=(8, 6))
-        self.line, = self.ax.plot([], [], 'b-o')
+        self.line, = self.ax.plot([], [], "b-o", label="Estimate")
         self.opt_line = None
         self.start_scatter = None
         self.end_scatter = None
+        self.heading_arrow = None
 
-        # self.ax.set_xlabel('X position')
-        # self.ax.set_ylabel('Y position')
+        self.ax.set_xlabel("X position")
+        self.ax.set_ylabel("Y position")
         self.ax.grid(True)
         self.ax.set_aspect('equal')
         self.ax.set_axis_off()
@@ -67,6 +71,12 @@ class VehiclePathLiveAnimator:
                 self.opt_line, = self.ax.plot([], [], 'g--', label='Optimized')
             self.new_data_available = True
 
+    def add_loop_edge(self, i: int, j: int) -> None:
+        """Record a detected loop for visualisation."""
+        with self.lock:
+            self.loop_edges.append((i, j))
+            self.new_data_available = True
+
     def _update_plot_loop(self):
         while self.running:
             if self.new_data_available:
@@ -88,6 +98,38 @@ class VehiclePathLiveAnimator:
                         self.end_scatter.remove()
                     self.end_scatter = self.ax.scatter(path[-1, 0], path[-1, 1], color='red', label='End')
 
+                    # draw heading arrow for the latest pose
+                    last_pose = self.poses[-1]
+                    heading = last_pose[:2, 0]
+                    pos = last_pose[:2, 2]
+                    if self.heading_arrow is not None:
+                        self.heading_arrow.remove()
+                    arrow_scale = 0.5
+                    self.heading_arrow = self.ax.arrow(
+                        pos[0], pos[1],
+                        heading[0] * arrow_scale,
+                        heading[1] * arrow_scale,
+                        head_width=0.3,
+                        head_length=0.4,
+                        fc="orange",
+                        ec="orange",
+                        label="Heading",
+                    )
+
+                    for line in self.loop_lines:
+                        line.remove()
+                    self.loop_lines.clear()
+                    for idx, (i, j) in enumerate(self.loop_edges):
+                        p1, p2 = path[i], path[j]
+                        line, = self.ax.plot(
+                            [p1[0], p2[0]],
+                            [p1[1], p2[1]],
+                            "m--",
+                            label="Loop" if idx == 0 else "_nolegend_",
+                        )
+                        self.loop_lines.append(line)
+                    self.ax.legend()
+
                     self.new_data_available = False
 
                 self.fig.canvas.draw()
@@ -95,10 +137,12 @@ class VehiclePathLiveAnimator:
 
             time.sleep(0.05)  # Sleep a bit to avoid busy-waiting
 
-    def stop(self):
-        """Terminate the background plot thread and display the result."""
+    def stop(self, save_path: str | None = None) -> None:
+        """Terminate the background plot thread and optionally save the final plot."""
 
         self.running = False
         self.update_thread.join()
+        if save_path:
+            self.fig.savefig(save_path, bbox_inches="tight")
         plt.ioff()
         plt.show()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import numpy as np
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from slam_path_estimator import VehiclePathLiveAnimator
+
+
+def test_animator_loop_edge(tmp_path):
+    os.environ["MPLBACKEND"] = "Agg"
+    anim = VehiclePathLiveAnimator()
+    anim.add_transform(np.eye(2), np.array([1.0, 0.0]))
+    anim.add_transform(np.eye(2), np.array([1.0, 0.0]))
+    anim.add_loop_edge(0, 2)
+    time.sleep(0.2)
+    save = tmp_path / "plot.png"
+    anim.stop(str(save))
+    assert (0, 2) in anim.loop_edges
+    assert save.exists()

--- a/visual_slam_offline_entry_point.py
+++ b/visual_slam_offline_entry_point.py
@@ -141,6 +141,11 @@ def main() -> None:
         action="store_true",
         help="Mask dynamic regions before feature detection",
     )
+    parser.add_argument(
+        "--save_plot",
+        help="Path to save the final trajectory plot",
+        default=None,
+    )
     args = parser.parse_args()
 
     path_estimator = VehiclePathLiveAnimator()
@@ -195,6 +200,7 @@ def main() -> None:
             try:
                 _, R_loop, t_loop = estimate_homography_from_orb(loop_kp, loop_desc, curr_keypoints, curr_desc, K)
                 pose_graph.add_loop(loop_id, frame_id, R_loop, t_loop)
+                path_estimator.add_loop_edge(loop_id, frame_id)
                 optimized = pose_graph.optimize()
                 path_estimator.set_optimized_poses(optimized)
                 orig = np.array([p[:2,2] for p in pose_graph.poses])
@@ -209,7 +215,7 @@ def main() -> None:
         prev_frame = curr_img
         time.sleep(0.1)  # simulate results arriving slowly
         plt.pause(0.001)  # <-- THIS IS CRITICAL!!!
-    path_estimator.stop()
+    path_estimator.stop(args.save_plot)
 
     # plt.axis('off')
     # plt.gca().set_position([0, 0, 1, 1])  # Fill the entire figure


### PR DESCRIPTION
## Summary
- allow saving the final trajectory plot from CLI
- visualize camera orientation with an arrow
- highlight loop closures with magenta dashed lines
- add unit test covering loop-edge drawing

## Testing
- `pytest -q`
- `python visual_slam_offline_entry_point.py --video sharp_curve.mp4 --max_frames 5 --save_plot demo_plot.png`

------
https://chatgpt.com/codex/tasks/task_e_685412f215648322bfec3ef2024ac1a3