### PR TITLE
Add interactive SLAM viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ Useful flags:
   simple frame‑difference algorithm.
 * `--intrinsics_file path` – load calibrated intrinsics (`fx fy cx cy`) from a text file.
 
+## Interactive viewer
+
+The `slam_viewer.py` script provides a side-by-side interface that plays the input video while plotting the estimated trajectory. Matched feature points and basic pose diagnostics are drawn on top of each frame.
+
+
+Launch the viewer with:
+```bash
+python slam_viewer.py --video sharp_curve.mp4
+```
+
+Useful options:
+
+* `--step` – advance frames one-by-one.
+* `--show3d` – toggle a 3-D scatter of the path.
+* `--intrinsics_file` – supply camera intrinsics (`fx fy cx cy`).
+
+The viewer requires `opencv-python` and `matplotlib`.
+
 ## Benchmarking with the TUM RGB‑D dataset
 
 Download one of the TUM RGB‑D sequences from the official website or its

--- a/slam_viewer.py
+++ b/slam_viewer.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Unified visualisation interface for the SLAM demo.
+
+This script plays back a video while estimating the camera trajectory.
+The left panel shows the current video frame with matched keypoints
+between the previous and current image.  The right panel plots the
+estimated 2‑D trajectory with the latest camera position highlighted.
+
+Optionally a third 3‑D panel visualises the path in space.  Per frame
+basic diagnostic information is overlayed on the image including the
+number of features, matches and the current pose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import cv2
+import numpy as np
+import matplotlib.pyplot as plt
+from cam_intrinsics_estimation import make_K, load_K_from_file
+
+
+# ------------------------------- helpers -----------------------------------
+
+def rotation_to_euler_xyz(R: np.ndarray) -> tuple[float, float, float]:
+    """Return yaw, pitch, roll (Z, Y, X) from a rotation matrix."""
+    sy = math.sqrt(R[0, 0] ** 2 + R[1, 0] ** 2)
+    singular = sy < 1e-6
+    if not singular:
+        yaw = math.atan2(R[1, 0], R[0, 0])
+        pitch = math.atan2(-R[2, 0], sy)
+        roll = math.atan2(R[2, 1], R[2, 2])
+    else:  # Gimbal lock
+        yaw = math.atan2(-R[1, 2], R[1, 1])
+        pitch = math.atan2(-R[2, 0], sy)
+        roll = 0.0
+    return np.degrees([yaw, pitch, roll])
+
+
+# ------------------------------- main loop ---------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Side‑by‑side SLAM viewer")
+    parser.add_argument("--video", required=True, help="Path to input video")
+    parser.add_argument(
+        "--intrinsics_file", help="Optional intrinsics file with fx fy cx cy"
+    )
+    parser.add_argument(
+        "--step", action="store_true", help="Advance frames on key press"
+    )
+    parser.add_argument(
+        "--show3d", action="store_true", help="Display 3‑D scatter of the path"
+    )
+    args = parser.parse_args()
+
+    cap = cv2.VideoCapture(args.video)
+    if not cap.isOpened():
+        raise SystemExit(f"Could not open video {args.video}")
+
+    ok, first_frame = cap.read()
+    if not ok:
+        raise SystemExit("Video is empty")
+
+    h, w = first_frame.shape[:2]
+    if args.intrinsics_file:
+        K = load_K_from_file(args.intrinsics_file)
+    else:
+        K = make_K(w, h)
+
+    orb = cv2.ORB_create(1000)
+    matcher = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+
+    plt.ion()
+    cols = 3 if args.show3d else 2
+    fig = plt.figure(figsize=(5 * cols, 5))
+    ax_img = fig.add_subplot(1, cols, 1)
+    ax_traj = fig.add_subplot(1, cols, 2)
+    ax_traj.set_title("Estimated trajectory")
+    ax_traj.set_xlabel("X")
+    ax_traj.set_ylabel("Z")
+    ax_traj.set_aspect("equal")
+
+    ax3d = None
+    if args.show3d:
+        ax3d = fig.add_subplot(1, 3, 3, projection="3d")
+        ax3d.set_title("3‑D path")
+        ax3d.set_xlabel("X")
+        ax3d.set_ylabel("Y")
+        ax3d.set_zlabel("Z")
+
+    poses = [np.eye(4)]
+    positions = [np.zeros(3)]
+    path_line, = ax_traj.plot([], [], "b-")
+    curr_point = ax_traj.scatter([], [], c="r")
+
+    prev_gray = cv2.cvtColor(first_frame, cv2.COLOR_BGR2GRAY)
+    prev_kp, prev_desc = orb.detectAndCompute(prev_gray, None)
+
+    frame_id = 0
+
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        frame_id += 1
+
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        kp, desc = orb.detectAndCompute(gray, None)
+
+        matches = []
+        if prev_desc is not None and desc is not None and len(prev_desc) > 0 and len(desc) > 0:
+            matches = matcher.match(prev_desc, desc)
+            matches = sorted(matches, key=lambda m: m.distance)
+
+        pts_prev = np.float32([prev_kp[m.queryIdx].pt for m in matches]).reshape(-1, 1, 2)
+        pts_curr = np.float32([kp[m.trainIdx].pt for m in matches]).reshape(-1, 1, 2)
+
+        R = np.eye(3)
+        t = np.zeros((3, 1))
+        inlier_mask = None
+        inlier_ratio = 0.0
+        if len(matches) >= 8:
+            E, inlier_mask = cv2.findEssentialMat(
+                pts_prev, pts_curr, K, method=cv2.RANSAC, threshold=1.0
+            )
+            if E is not None:
+                _, R, t, inlier_mask = cv2.recoverPose(
+                    E, pts_prev, pts_curr, K, mask=inlier_mask
+                )
+                inlier_mask = inlier_mask.ravel().astype(bool)
+                inlier_ratio = float(inlier_mask.sum()) / len(matches)
+            else:
+                inlier_mask = np.zeros(len(matches), dtype=bool)
+        else:
+            inlier_mask = np.zeros(len(matches), dtype=bool)
+
+        # Update global pose
+        T = np.eye(4)
+        T[:3, :3] = R
+        T[:3, 3] = t.ravel()
+        new_pose = poses[-1] @ T
+        poses.append(new_pose)
+        pos = new_pose[:3, 3]
+        positions.append(pos)
+
+        traj = np.array(positions)
+        path_line.set_data(traj[:, 0], traj[:, 2])
+        curr_point.remove()
+        curr_point = ax_traj.scatter(traj[-1, 0], traj[-1, 2], c="r")
+
+        if ax3d is not None:
+            ax3d.clear()
+            ax3d.set_title("3‑D path")
+            ax3d.set_xlabel("X")
+            ax3d.set_ylabel("Y")
+            ax3d.set_zlabel("Z")
+            ax3d.plot(traj[:, 0], traj[:, 1], traj[:, 2], "b-")
+            ax3d.scatter(traj[-1, 0], traj[-1, 1], traj[-1, 2], c="r")
+
+        # Draw matches and inliers on the frame
+        display = frame.copy()
+        for idx, m in enumerate(matches):
+            pt_prev = tuple(map(int, prev_kp[m.queryIdx].pt))
+            pt_curr = tuple(map(int, kp[m.trainIdx].pt))
+            color = (0, 255, 0) if inlier_mask[idx] else (0, 0, 255)
+            cv2.line(display, pt_prev, pt_curr, color, 1)
+            cv2.circle(display, pt_curr, 2, color, -1)
+
+        yaw, pitch, roll = rotation_to_euler_xyz(R)
+        text = (
+            f"Frame: {frame_id}\n"
+            f"Features: {len(kp)}\n"
+            f"Matches: {len(matches)}\n"
+            f"Inlier ratio: {inlier_ratio:.2f}\n"
+            f"Pos: {pos[0]:.2f}, {pos[1]:.2f}, {pos[2]:.2f}\n"
+            f"Yaw/Pitch/Roll: {yaw:.1f}, {pitch:.1f}, {roll:.1f}"
+        )
+
+        ax_img.clear()
+        ax_img.imshow(cv2.cvtColor(display, cv2.COLOR_BGR2RGB))
+        ax_img.set_title("Frame and matches")
+        ax_img.axis("off")
+        ax_img.text(
+            0.02,
+            0.98,
+            text,
+            color="yellow",
+            fontsize=8,
+            va="top",
+            transform=ax_img.transAxes,
+            bbox=dict(boxstyle="round", facecolor="black", alpha=0.5),
+        )
+
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+        if args.step:
+            plt.waitforbuttonpress()
+        else:
+            plt.pause(0.001)
+
+        prev_gray, prev_kp, prev_desc = gray, kp, desc
+
+    plt.ioff()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `slam_viewer.py` for side-by-side video playback, trajectory plotting, optional 3‑D view and per-frame diagnostics
- document the new viewer and include a sample screenshot
- drop committed screenshot to keep repo lightweight

## Testing
- `pip install numpy opencv-python-headless matplotlib scikit-learn pytest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e678968c883228ed60b0fd91687e3