### PR TITLE
Use test video for demos and improve robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+NVidiaRun2.mp4
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The most relevant modules are:
 
 ## Running the pipeline
 
-The repository ships with a short example clip `sharp_curve.mp4`.  Use the
+The demos download a short example clip on first use.  Use the
 entry‑point script to process the video and display the recovered trajectory:
 
 ```bash
-python visual_slam_offline_entry_point.py --video sharp_curve.mp4
+python visual_slam_offline_entry_point.py
 ```
 
 The script loads frames from the given video, detects ORB keypoints and
@@ -52,7 +52,7 @@ The `slam_viewer.py` script provides a side-by-side interface that plays the inp
 
 Launch the viewer with:
 ```bash
-python slam_viewer.py --video sharp_curve.mp4
+python slam_viewer.py
 ```
 
 Useful options:

--- a/demo_utils.py
+++ b/demo_utils.py
@@ -1,0 +1,35 @@
+"""Utilities for demo scripts.
+
+Provides helper to ensure the sample video used in tests is available.
+If the expected video file is missing it will be downloaded from the
+project's known URL.  This avoids depending on a checked in binary file
+while still allowing the demos and visualisations to run out of the box.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import urllib.request
+
+TEST_VIDEO_URL = (
+    "https://raw.githubusercontent.com/gurugithub/Carnd-Project3-Behavioral-Cloning/master/NVidiaRun2.mp4"
+)
+DEFAULT_VIDEO_PATH = Path("NVidiaRun2.mp4")
+
+
+def ensure_sample_video(path: str | Path = DEFAULT_VIDEO_PATH) -> Path:
+    """Return a path to a local copy of the sample video.
+
+    The test suite downloads this video dynamically.  For the demos we do the
+    same if the file is missing so that users can simply run the scripts
+    without additional setup.  If the download fails a ``SystemExit`` is
+    raised with a helpful message.
+    """
+    path = Path(path)
+    if path.exists():
+        return path
+    try:
+        print(f"Downloading sample video to {path}...")
+        urllib.request.urlretrieve(TEST_VIDEO_URL, path)
+    except Exception as exc:  # pragma: no cover - network failures
+        raise SystemExit(f"Unable to download sample video: {exc}")
+    return path


### PR DESCRIPTION
## Summary
- Download test NVidia video on demand and use it as the default demo clip
- Make `visual_slam_offline_entry_point.py` and `slam_viewer.py` fall back to this clip when no video is supplied
- Handle missing video files and bad SLAM geometry gracefully; update README

## Testing
- `pytest -q`
- `python visual_slam_offline_entry_point.py --max_frames 10 --pause_time 0 --sleep_time 0`
- `MPLBACKEND=Agg timeout 15 python slam_viewer.py --show3d`
- `python slam_viewer.py --video missing.mp4` (fails gracefully)


------
https://chatgpt.com/codex/tasks/task_e_6890b6d8394c8322a4a6c1b955266742